### PR TITLE
Add saving option for plots

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,3 +71,8 @@ jobs:
         run: |
           set -vxuo pipefail
           pytest -s -vv
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test-artifacts
+          path: /tmp/test_emulated_basler_camera_exposure_ms*.png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.2
+    rev: 5.11.4
     hooks:
       - id: isort
   - repo: https://github.com/kynan/nbstripout

--- a/ophyd_basler/basler_camera.py
+++ b/ophyd_basler/basler_camera.py
@@ -1,13 +1,10 @@
 import datetime
 import itertools
-import logging
 import os
-import tempfile
 import warnings
 from collections import deque
 from pathlib import Path
 
-import cv2
 import h5py
 import numpy as np
 from event_model import compose_resource
@@ -17,8 +14,8 @@ from ophyd.sim import NullStatus, new_uid
 from pypylon import pylon
 
 from . import ExternalFileReference
-
-logger = logging.getLogger("basler")
+from .custom_images import save_images
+from .utils import logger_basler as logger
 
 
 class BaslerCamera(Device):
@@ -118,11 +115,7 @@ class BaslerCamera(Device):
                 "passed."
             )
         if images is not None:
-            img_dir = tempfile.mkdtemp()
-            logger.info(f"Using '{img_dir}' to save {len(images)} images to.")
-            for i, image in enumerate(images):
-                cv2.imwrite(os.path.join(img_dir, "pattern_%03d.png" % i), image)
-            logger.info(f"Saved {len(os.listdir(img_dir))} images into '{img_dir}'")
+            img_dir = save_images(images)
 
         elif img_dir is not None:
             logger.info(f"Using '{img_dir}' with the existing {len(os.listdir(img_dir))} images.")

--- a/ophyd_basler/custom_images.py
+++ b/ophyd_basler/custom_images.py
@@ -1,4 +1,10 @@
+import os
+import tempfile
+
+import cv2
 import numpy as np
+
+from ophyd_basler.utils import logger_basler as logger
 
 
 def gaussian_2d(x, y, a, cx, cy, sx, sy):
@@ -42,3 +48,15 @@ def get_wandering_gaussian_beam(nf, nx, ny, seed=0):
     X, Y = np.meshgrid(np.arange(nx), np.arange(ny))
 
     return gaussian_2d(X[None, :, :], Y[None, :, :], *beam_params[:, :, None, None])
+
+
+def save_images(images, img_dir=None):
+    if img_dir is None:
+        img_dir = tempfile.mkdtemp()
+
+    logger.info(f"Using '{img_dir}' to save {len(images)} images to.")
+    for i, image in enumerate(images):
+        cv2.imwrite(os.path.join(img_dir, "pattern_%03d.png" % i), image)
+    logger.info(f"Saved {len(os.listdir(img_dir))} images into '{img_dir}'")
+
+    return img_dir

--- a/ophyd_basler/custom_images.py
+++ b/ophyd_basler/custom_images.py
@@ -53,6 +53,9 @@ def get_wandering_gaussian_beam(nf, nx, ny, seed=0):
 def save_images(images, img_dir=None):
     if img_dir is None:
         img_dir = tempfile.mkdtemp()
+    else:
+        if not os.path.exists(img_dir):
+            os.makedirs(img_dir, exist_ok=True)
 
     logger.info(f"Using '{img_dir}' to save {len(images)} images to.")
     for i, image in enumerate(images):

--- a/ophyd_basler/tests/test_emulated_camera.py
+++ b/ophyd_basler/tests/test_emulated_camera.py
@@ -7,10 +7,11 @@ import pytest
 import ophyd_basler
 from ophyd_basler.basler_camera import BaslerCamera
 from ophyd_basler.custom_images import get_wandering_gaussian_beam
+from ophyd_basler.utils import plot_images
 
 
 @pytest.mark.parametrize("exposure_ms", [200, 2000])
-def test_emulated_basler_camera(RE, db, make_dirs, exposure_ms, num_counts=5):
+def test_emulated_basler_camera(RE, db, make_dirs, exposure_ms, num_counts=8):
     os.environ["PYLON_CAMEMU"] = "1"
 
     print(ophyd_basler.available_devices())
@@ -40,3 +41,7 @@ def test_emulated_basler_camera(RE, db, make_dirs, exposure_ms, num_counts=5):
     print(images)
 
     assert images.shape == (num_counts, 1040, 1024)
+
+    plot_images(
+        images, ncols=4, nrows=2, save_path=f"/tmp/test_emulated_basler_camera_exposure_ms={exposure_ms:d}.png"
+    )

--- a/ophyd_basler/utils.py
+++ b/ophyd_basler/utils.py
@@ -20,7 +20,7 @@ def configure_logger(logger, log_level=logging.DEBUG, handlers=[StreamHandler]):
         handler.setLevel(log_level)
 
 
-def plot_images(data, nrows=None, ncols=None):
+def plot_images(data, nrows=None, ncols=None, save_path=None):
     """
     Usage
     -----
@@ -43,3 +43,6 @@ def plot_images(data, nrows=None, ncols=None):
         for col in range(ncols):
             print(f"  {col = } --> {ax[row][col]}")
             ax[row][col].imshow(data[row * ncols + col], vmin=data.min(), vmax=data.max())
+
+    if save_path is not None:
+        plt.savefig(save_path)


### PR DESCRIPTION
This PR adds a couple of features:
- add an option for `plot_images(...)` to save the plotted images from databroker to a file and upload them as an artifact;
- add `save_images(...)` to dump the series of generated WGB images to the specific directory.